### PR TITLE
fix: update copyright year to be dynamic

### DIFF
--- a/components/hackersmang/Copyright.tsx
+++ b/components/hackersmang/Copyright.tsx
@@ -17,7 +17,7 @@ export default function Copyright() {
                 </Link>
             </div>
             <div className='text-neutral-navy outfit-extra-light'>
-                © 2025 Hackerspace Mangaluru. All rights reserved
+                © {new Date().getFullYear()} Hackerspace Mangaluru. All rights reserved
             </div>
         </div>
     )


### PR DESCRIPTION
This PR updates the footer copyright year from a hardcoded 2025 to a dynamic new Date().getFullYear(), ensuring it never gets stale.
