### PR TITLE
a11y: improve accessibility across homepage

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,20 @@
     @apply bg-[#d4e20b] text-black
 }
 
+/* Accessibility: Skip to main content link */
+.skip-to-content {
+    @apply absolute -top-full left-4 z-[100] px-4 py-2 bg-neutral-navy text-white rounded-b-lg font-semibold text-sm transition-all duration-200;
+}
+
+.skip-to-content:focus {
+    @apply top-0;
+}
+
+/* Accessibility: Visible focus indicators */
+*:focus-visible {
+    @apply outline-2 outline-offset-2 outline-neutral-navy;
+}
+
 body,
 html {
     font-family: sans-serif;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,6 +56,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
+        <a href="#main-content" className="skip-to-content">
+          Skip to main content
+        </a>
         {children}
         <SpeedInsights />
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,7 @@ export default function Home() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(homepageJsonLd) }}
       />
-      <main className="relative bg-white h-full w-full">
+      <main id="main-content" className="relative bg-white h-full w-full">
         <Header />
         <Hero />
         <FutureSection />

--- a/components/hackersmang/FutureSection.tsx
+++ b/components/hackersmang/FutureSection.tsx
@@ -22,7 +22,7 @@ export default function FutureSection() {
             <div className="relative z-10">
               {/* Icon - Three Users */}
               <div className="w-16 h-16 mb-6 flex items-center justify-center">
-                <svg className="w-12 h-12 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-12 h-12 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M16 4c0-1.11.89-2 2-2s2 .89 2 2-.89 2-2 2-2-.89-2-2zm4 18v-6h2.5l-2.54-7.63A1.5 1.5 0 0 0 18.54 8H16c-.8 0-1.54.37-2.01.99L12 11l-1.99-2.01A2.5 2.5 0 0 0 8 8H5.46c-.8 0-1.54.37-2.01.99L1 12.5V22h2v-6h2.5l2.5 6h2l-2.5-6H12v6h2v-6h2.5l2.5 6h2l-2.5-6H20v6h2z"/>
                 </svg>
               </div>
@@ -44,7 +44,7 @@ export default function FutureSection() {
             <div className="relative z-10">
               {/* Icon - Handshake */}
               <div className="w-16 h-16 mb-6 flex items-center justify-center">
-                <svg className="w-12 h-12 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-12 h-12 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
                 </svg>
               </div>
@@ -66,7 +66,7 @@ export default function FutureSection() {
             <div className="relative z-10">
               {/* Icon - Shooting Star */}
               <div className="w-16 h-16 mb-6 flex items-center justify-center">
-                <svg className="w-12 h-12 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-12 h-12 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
                 </svg>
               </div>
@@ -88,7 +88,7 @@ export default function FutureSection() {
             <div className="relative z-10">
               {/* Icon - Lightbulb */}
               <div className="w-16 h-16 mb-6 flex items-center justify-center">
-                <svg className="w-12 h-12 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-12 h-12 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6A4.997 4.997 0 0 1 7 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z"/>
                 </svg>
               </div>

--- a/components/hackersmang/Header.tsx
+++ b/components/hackersmang/Header.tsx
@@ -4,8 +4,8 @@ import Link from "next/link"
 export default function Header() {
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-[60] bg-neutral-white shadow-md py-2">
-      <div className="flex items-center justify-between h-16 max-w-7xl mx-auto px-5">
+    <header className="fixed top-0 left-0 right-0 z-[60] bg-neutral-white shadow-md py-2" role="banner">
+      <nav className="flex items-center justify-between h-16 max-w-7xl mx-auto px-5" aria-label="Main navigation">
         {/* Logo Section */}
         <div className="h-full w-fit flex justify-center items-center text-sm p-0 cursor-pointer">
           <Link href="/" aria-label="Hackerspace Mangaluru home">
@@ -29,7 +29,7 @@ export default function Header() {
           <div className="relative flex items-center gap-2">
             {/* Icon */}
             <div className="w-5 h-5 flex items-center justify-center">
-              <svg className="w-4 h-4 transition-transform duration-300 group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-4 h-4 transition-transform duration-300 group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
             </div>
@@ -43,7 +43,7 @@ export default function Header() {
             <div className="w-1.5 h-1.5 bg-neutral-100 rounded-full animate-pulse opacity-60 group-hover:opacity-100 transition-opacity duration-300"></div>
           </div>
         </Link>
-      </div>
+      </nav>
     </header>
   )
 }

--- a/components/hackersmang/Hero.tsx
+++ b/components/hackersmang/Hero.tsx
@@ -27,12 +27,12 @@ export default function Hero() {
           </p>
 
           {/* Interactive Stats */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 lg:gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 lg:gap-6" role="group" aria-label="Community statistics">
             <div className="group bg-secondary-yellow p-6 lg:p-8 rounded-2xl border border-primary-yellow/20 hover:border-primary-yellow/40 transition-all duration-300 hover:scale-105 cursor-default">
               <div className="flex items-center justify-between mb-3">
                 <div className="text-3xl lg:text-4xl outfit-extra-bold text-neutral-navy">12+</div>
                 <div className="w-16 h-16 rounded-lg flex items-center justify-center">
-                  <svg className="w-8 h-8 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-8 h-8 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
                   </svg>
                 </div>
@@ -43,7 +43,7 @@ export default function Hero() {
               <div className="flex items-center justify-between mb-3">
                 <div className="text-3xl lg:text-4xl outfit-extra-bold text-neutral-navy">500+</div>
                 <div className="w-16 h-16 rounded-lg flex items-center justify-center">
-                  <svg className="w-8 h-8 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-8 h-8 text-neutral-navy" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M16 4c0-1.11.89-2 2-2s2 .89 2 2-.89 2-2 2-2-.89-2-2zm4 18v-6h2.5l-2.54-7.63A1.5 1.5 0 0 0 18.54 8H16c-.8 0-1.54.37-2.01.99L12 11l-1.99-2.01A2.5 2.5 0 0 0 8 8H5.46c-.8 0-1.54.37-2.01.99L1 12.5V22h2v-6h2.5l2.5 6h2l-2.5-6H12v6h2v-6h2.5l2.5 6h2l-2.5-6H20v6h2z"/>
                   </svg>
                 </div>


### PR DESCRIPTION
This PR implements several core accessibility improvements across the homepage:

1. Adds a "Skip to main content" link for keyboard users
2. Adds visible focus indicators (`:focus-visible`) globally
3. Adds `aria-hidden="true"` to purely decorative SVGs
4. Adds semantic `<nav>` and` role="banner"` to the header
5. Adds `role="group"` labeling to the stats section